### PR TITLE
Configure Vercel build and fix type checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -253,20 +253,25 @@ export default function Dashboard() {
 
   const generatePerformanceInsights = () => {
     const insights: any[] = [];
-    const { repStats } = calculateRepPerformance();
+    const { repStats } = calculateRepPerformance() as { repStats: any[] };
     
     // Best performer insight
     if (repStats.length > 0) {
-      const topPerformer = repStats.reduce((best: any, current: any) => 
-        (current.conversionPerformance > best.conversionPerformance) ? current : best, repStats[0]);
-      
-      if (topPerformer && topPerformer.name) {
+      const topPerformer: any = repStats.reduce(
+        (best: any, current: any) =>
+          current.conversionPerformance > best.conversionPerformance
+            ? current
+            : best,
+        repStats[0],
+      );
+
+      if (topPerformer?.name) {
         insights.push({
           type: 'Top Performer',
           message: `${topPerformer.name} is leading with ${topPerformer.cohortConversionRate?.toFixed(1) || 0}% conversion rate`,
           action: 'Consider having them mentor underperformers',
           icon: TrendingUp,
-          color: 'success'
+          color: 'success',
         });
       }
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist/public",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel configuration with build command, static output directory, and rewrites
- cast rep statistics for top-performer insight to satisfy TypeScript
- ignore node_modules and build output in git

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68b737e393e8832689e986fd0a7e3cce